### PR TITLE
Allow for optionally returning results

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,10 @@ module.exports = function(name, options) {
   var options = _.defaults(options, {
     name: false,
     dirname: '.',
+    ast: true,
+    css: true,
+    cleanCss: true,
+    stats: true
   });
   var results = {};
   var filepath;
@@ -63,10 +67,12 @@ module.exports = function(name, options) {
 
   var style = results.style || fs.existsSync(filepath + '/index.css') ? 'index.css' : false;
   if (style) {
-    results.ast = parseStyle(style);
-    results.css = results.ast.css;
-    results.cleanCss = postcss().use(cleanDisplay()).process(results.css).css;
-    results.stats = cssstats(results.css);
+    var ast = parseStyle(style);
+    var css = ast.css;
+    if (options.ast) { results.ast = ast; }
+    if (options.css) { results.css = css; }
+    if (options.cleanCss) { results.cleanCss = postcss().use(cleanDisplay()).process(css).css; }
+    if (options.stats) { results.stats = cssstats(css); }
   }
 
   results.title = _.capitalize(results.name);
@@ -75,4 +81,3 @@ module.exports = function(name, options) {
   return results;
 
 };
-

--- a/test/index.js
+++ b/test/index.js
@@ -11,32 +11,31 @@ var basscssGridInfo = getModuleInfo('basscss-grid');
 describe('get-module-info', function() {
 
   it('should be an object', function() {
-    assert(typeof postcssInfo, 'object');
+    assert.equal(typeof postcssInfo, 'object');
   });
 
   it('should have a name', function() {
-    assert(typeof postcssInfo.name, 'string');
+    assert.equal(typeof postcssInfo.name, 'string');
   });
 
   it('should have a version', function() {
-    assert(typeof postcssInfo.version, 'string');
+    assert.equal(typeof postcssInfo.version, 'string');
   });
 
   it('should have a title', function() {
-    assert(typeof postcssInfo.title, 'string');
+    assert.equal(typeof postcssInfo.title, 'string');
   });
 
   it('should have a readme', function() {
-    assert(typeof postcssInfo.readme, 'string');
+    assert.equal(typeof postcssInfo.readme, 'string');
   });
 
   it('should get css', function() {
-    assert(typeof basscssGridInfo.css, 'string');
+    assert.equal(typeof basscssGridInfo.css, 'string');
   });
 
   it('should get css stats', function() {
-    assert(typeof basscssGridInfo.stats, 'object');
+    assert.equal(typeof basscssGridInfo.stats, 'object');
   });
 
 });
-

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 var getModuleInfo = require('..');
 
 var postcssInfo = getModuleInfo('postcss');
-var basscssGridInfo = getModuleInfo('basscss-grid');
+var basscssGridInfo = getModuleInfo('basscss-grid', { ast: false });
 
 
 describe('get-module-info', function() {
@@ -36,6 +36,10 @@ describe('get-module-info', function() {
 
   it('should get css stats', function() {
     assert.equal(typeof basscssGridInfo.stats, 'object');
+  });
+
+  it('should allow optional results', function() {
+    assert.equal(typeof basscssGridInfo.ast, 'undefined');
   });
 
 });


### PR DESCRIPTION
In instances where the returned data is used in the browser, some info is unnecessary/adds unwanted weight. This adds the option to exclude some info from the results. By default, everything will be returned.

Also added a test new options, and changed all tests to use `assert.equal()` (tests actual-expected equality) instead of `assert()` (tests single-value truthiness).
